### PR TITLE
chore: distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# Steer
+This is a tool that helps performs a URL that can be used to request google oauth2 permition and google drive. This tool do not creates any http request instead creates the URL to perform the *request*, with this in mind you can utilize any http client and http server.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+with open('./README.md') as doc:
+    readme = doc.read()
+
+setup(
+    name="steer",
+    version="1.0.2.post1",
+    author="Fernando A.",
+    url="https://github.com/fernando-gap/steer",
+    license="MIT",
+    packages=['steer/oauth', 'steer/drive'],
+    description="Create URLS to use create google oauth2 and drive api requests.",
+    long_description=readme,
+    long_description_content_type="text/markdown"
+)

--- a/steer/__init__.py
+++ b/steer/__init__.py
@@ -1,5 +1,0 @@
-# from steer import oauth2
-# from steer.challenge import S256
-# from steer.response import OAuth2Response
-# from steer.headers import Header, Simple, Multipart
-# from .drive import Upload


### PR DESCRIPTION
The distribution of the steer started. it still only supports
Linux platforms. The setup tools is being used to provide more
flexibilty in future dist. changes.

A brief description was added on README.md.