### PR TITLE
fix: code challenge can not be type None

### DIFF
--- a/steer/oauth/api.py
+++ b/steer/oauth/api.py
@@ -50,7 +50,7 @@ class OAuth2(_ParseParams):
             self.params = dict_params
 
 
-    def create(self, challenge = None):
+    def create(self, challenge = ''):
         """ Creates google authentication request URL for Desktop APPS.
 
         To create an oauth url it needs the following attributes:
@@ -68,7 +68,7 @@ class OAuth2(_ParseParams):
         params = self._create_url_params(self.params)
 
 
-        if challenge == None:
+        if challenge == '':
             return self._oauth_url + params
 
         self.code_challenge = challenge


### PR DESCRIPTION
The code_challenge was changed in #2  and passed to use an empty string.