### PR TITLE
fix: uneeded client_secret keyerror

### DIFF
--- a/steer/oauth/api.py
+++ b/steer/oauth/api.py
@@ -69,7 +69,7 @@ class OAuth2(_ParseParams):
         for key in self.params:
             if key not in valid:
                 create_params.pop(key)
-                    
+
             
         # assign self.params to use the params provided by the user
         # and store the params to create the url    

--- a/steer/oauth/api.py
+++ b/steer/oauth/api.py
@@ -60,9 +60,12 @@ class OAuth2(_ParseParams):
         valid = ['client_id', 'scope', 'response_type', 'redirect_uri']
         create_params = self.params.copy()
         # invalid attributes are removed
-        for key in valid:
-            if key not in self.params:
-                create_params.pop(key)
+        for key in create_params:
+            if key not in valid:
+                try:
+                    create_params.pop(key)
+                except KeyError:
+                    raise KeyError('missing required property')
             
             
         # assign self.params to use the params provided by the user

--- a/steer/oauth/api.py
+++ b/steer/oauth/api.py
@@ -59,14 +59,17 @@ class OAuth2(_ParseParams):
         
         valid = ['client_id', 'scope', 'response_type', 'redirect_uri']
         create_params = self.params.copy()
-        # invalid attributes are removed
+        
+        # check if all valid keys exists
         for key in create_params:
+            if key not in create_params:
+                raise KeyError(f'{key} is missing')
+        
+        # invalid attributes are removed
+        for key in self.params:
             if key not in valid:
-                try:
-                    create_params.pop(key)
-                except KeyError:
-                    raise KeyError('missing required property')
-            
+                create_params.pop(key)
+                    
             
         # assign self.params to use the params provided by the user
         # and store the params to create the url    


### PR DESCRIPTION
Wrong validation in for loop and if statements which was to be remove invalid attributes, but only tries to remove valid ones. Now if a valid key is missing an error is raised.